### PR TITLE
Fix conditional "bit' require

### DIFF
--- a/src/prometheus/compiler_secure/bytecode.lua
+++ b/src/prometheus/compiler_secure/bytecode.lua
@@ -4,7 +4,9 @@
 -- This Script contains the Bytecode library for Compiling to Prometheus Bytecode
 
 -- For Lua5.1 Compatibility
-local bit32 = require("bit") or require("prometheus.bit").bit32;
+local success, bit32 = pcall(require, "bit")
+if not success then bit32 = require("prometheus.bit").bit32 end
+
 local logger = require("logger");
 local util = require("prometheus.util");
 local vmstrings = require("prometheus.compiler_secure.vmstrings");


### PR DESCRIPTION
This PR is a fix to the problem presented in https://github.com/levno-710/Prometheus/issues/14

@levno-710 Ironically, the fix that you added actually doesn't work in non-jit environments because `require` throws a halting error, haha.

But this should do the trick! I tested it in a Docker container running ubuntu 18.04. `master` failed with the `require("bit")` error, my branch successfully ran the obfuscator.

Let me know if you'd rather this be styled differently - I had trouble finding the best way to write it.

P.S Loving the project! While I'm a huge proponent of open source, I've longed for a **good** obfuscator that can help keep our anticheat code from being easily read by wrongdoers (we primarily write Lua for Garry's Mod).

I'll keep an eye out for your progress and contribute where I can 👍 